### PR TITLE
fix: all bodies from backend are encoded in utf-8

### DIFF
--- a/lib/provider/backend.dart
+++ b/lib/provider/backend.dart
@@ -166,7 +166,7 @@ class BackendService {
     switch (response.statusCode) {
       case (200):
         if (decodeFromJson) {
-          return jsonDecode(response.body);
+          return jsonDecode(utf8.decode(response.bodyBytes));
         }
         return response;
       case (307):


### PR DESCRIPTION
there does not seem to be a nice way to globally set this on the backend side, so we are doing it here...