### PR TITLE
fix: set a max zoom for map to avoid grey tiles

### DIFF
--- a/lib/screens/map.dart
+++ b/lib/screens/map.dart
@@ -406,6 +406,7 @@ class _ActivityMarkerMapState extends State<ActivityMarkerMap>
       mapController: mapController.mapController,
       options: MapOptions(
           bounds: bounds,
+          maxZoom: 18,
           onMapEvent: (event) => onMapEvent(event, context),
           interactiveFlags: InteractiveFlag.all & ~InteractiveFlag.rotate),
       children: [


### PR DESCRIPTION
this happened when the zoom was to high and the tile server didnt return tiles anymore. The whole interaction with map got freezed when that happene.